### PR TITLE
Add unique validation error code

### DIFF
--- a/src/Validator/Constraints/VatNumber.php
+++ b/src/Validator/Constraints/VatNumber.php
@@ -9,5 +9,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class VatNumber extends Constraint
 {
+    public const INVALID_ERROR_CODE = '59421d43-d474-489c-b18c-7701329d51a0';
+
     public $message = '"{{ string }}" does not look like a valid VAT number.';
 }

--- a/src/Validator/Constraints/VatNumberValidator.php
+++ b/src/Validator/Constraints/VatNumberValidator.php
@@ -42,6 +42,7 @@ class VatNumberValidator extends ConstraintValidator
         if (false === $valid) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ string }}', $value)
+                ->setCode(VatNumber::INVALID_ERROR_CODE)
                 ->addViolation();
         }
     }

--- a/tests/Validator/Constraints/VatNumberValidatorTest.php
+++ b/tests/Validator/Constraints/VatNumberValidatorTest.php
@@ -43,6 +43,7 @@ class VatNumberValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate($value, $constraint);
         $this->buildViolation('myMessage')
             ->setParameter('{{ string }}', $value)
+            ->setCode('59421d43-d474-489c-b18c-7701329d51a0')
             ->assertRaised();
     }
 


### PR DESCRIPTION
A unique error-code allows for a machine-readable way to differentiate between types of validation errors.

[All](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php#L23) [Symfony](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/Bic.php#L30) [constraints](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/Blank.php#L25) [expose](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/CardScheme.php#L41) [a](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/Unique.php#L26) [unique](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/Country.php#L27) [error](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/CssColor.php#L38) [code](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/Count.php#L26) [for](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/Date.php#L25) [this](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/DivisibleBy.php#L23) [reason](https://github.com/symfony/symfony/blob/d468bfdde226bd968f059f16533bb0bdac1ee330/src/Symfony/Component/Validator/Constraints/Email.php#L32).

This PR adds a unique error-code to the `VatNumber` constraint.

---

This allows for example `Api-Platform` to display the error code. So consumers of your API know what went wrong without having to parse the error message.

### Before

A `code` of `null` is displayed. Forcing us to parse the error message to know what actually went wrong and act accordingly.

```json
{
    "type": "https://tools.ietf.org/html/rfc2616#section-10",
    "title": "An error occurred",
    "detail": "vat: \"BEfoobar\" does not look like a valid VAT number.",
    "violations": [
        {
            "propertyPath": "vat",
            "message": "\"BEfoobar\" does not look like a valid VAT number.",
            "code": null
        }
    ]
}
```

### After

A `code` of `59421d43-d474-489c-b18c-7701329d51a0` is displayed, meaning we can hardcode this into our application instead of parsing the error message.

```
{
    "type": "https://tools.ietf.org/html/rfc2616#section-10",
    "title": "An error occurred",
    "detail": "vat: \"BEfoobar\" does not look like a valid VAT number.",
    "violations": [
        {
            "propertyPath": "vat",
            "message": "\"BEfoobar\" does not look like a valid VAT number.",
            "code": "59421d43-d474-489c-b18c-7701329d51a0"
        }
    ]
}
```