### PR TITLE
Fix deprecation warning for native return types

### DIFF
--- a/src/VatBundle.php
+++ b/src/VatBundle.php
@@ -1,11 +1,12 @@
 <?php
 namespace Ibericode\Vat\Bundle;
 
-use Ibericode\Vat\Bundle\DependencyInjection\VatExtension; 
+use Ibericode\Vat\Bundle\DependencyInjection\VatExtension;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class VatBundle extends \Symfony\Component\HttpKernel\Bundle\Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension() : ?ExtensionInterface
     {
         return new VatExtension();
     }


### PR DESCRIPTION
Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "Ibericode\Vat\Bundle\VatBundle" now to avoid errors or add an explicit @return annotation to suppress this message.

https://wouterj.nl/2021/09/symfony-6-native-typing