### PR TITLE
Add void to VatNumberValidator::validate return type

### DIFF
--- a/src/Validator/Constraints/VatNumberValidator.php
+++ b/src/Validator/Constraints/VatNumberValidator.php
@@ -12,7 +12,7 @@ use Ibericode\Vat\Vies\ViesException;
 
 class VatNumberValidator extends ConstraintValidator
 {
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint) : void
     {
         if (!$constraint instanceof VatNumber) {
             throw new UnexpectedTypeException($constraint, VatNumber::class);


### PR DESCRIPTION
Fix notice: Method "Symfony\Component\Validator\ConstraintValidatorInterface::validate()" might add "void" as a native return type declaration in the future. Do the same in implementation "Ibericode\Vat\Bundle\Validator\Constraints\VatNumberValidator" now to avoid errors or add an explicit @return annotation to suppress this message.