### PR TITLE
Use DI to replace validator service used in symfony validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
         "symfony/validator": "^5.4|^6.0"
     },
     "require-dev": {
+        "ext-intl": "*",
+        "ext-soap": "*",
         "phpunit/phpunit": "^10.0"
     },
     "autoload": {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -19,6 +19,9 @@
         <service id="ibericode_vat.geolocator" class="Ibericode\Vat\Geolocator">
             <argument key="$service">%ibericode_vat.geolocator.service%</argument>
         </service>
+        <service id="Ibericode\Vat\Bundle\Validator\Constraints\VatNumberValidator">
+            <argument key="$validator">%ibericode_vat.validator%</argument>
+        </service>
 
         <!-- autowiring class names -->
         <service id="Ibericode\Vat\Countries" alias="ibericode_vat.countries" />

--- a/src/Validator/Constraints/VatNumberValidator.php
+++ b/src/Validator/Constraints/VatNumberValidator.php
@@ -12,6 +12,10 @@ use Ibericode\Vat\Vies\ViesException;
 
 class VatNumberValidator extends ConstraintValidator
 {
+    public function __construct(private Validator $validator = new Validator())
+    {
+    }
+
     public function validate(mixed $value, Constraint $constraint) : void
     {
         if (!$constraint instanceof VatNumber) {
@@ -28,10 +32,9 @@ class VatNumberValidator extends ConstraintValidator
             throw new UnexpectedValueException($value, 'string');
         }
 
-        $validator = new Validator();
         if ($constraint->checkExistence) {
             try {
-                $valid = $validator->validateVatNumber($value);
+                $valid = $this->validator->validateVatNumber($value);
             } catch (ViesException $e) {
                 // ignore VIES VAT exceptions (when the service is down)
                 // this could mean that an unexisting VAT number passes validation,
@@ -39,7 +42,7 @@ class VatNumberValidator extends ConstraintValidator
                 $valid = true;
             }
         } else {
-            $valid = $validator->validateVatNumberFormat($value);
+            $valid = $this->validator->validateVatNumberFormat($value);
         }
 
         if (false === $valid) {

--- a/tests/DependencyInjection/VatExtensionTest.php
+++ b/tests/DependencyInjection/VatExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace Ibericode\Vat\Bundle\Tests\DependencyInjection;
 
+use Ibericode\Vat\Bundle\Validator\Constraints\VatNumberValidator;
 use Ibericode\Vat\Countries;
 use Ibericode\Vat\Geolocator;
 use Ibericode\Vat\Rates;
@@ -26,5 +27,6 @@ class VatExtensionTest extends TestCase
         $this->assertTrue($container->has(Rates::class), 'Rates class is wired');
         $this->assertTrue($container->has(Validator::class), 'Validator class is wired');
         $this->assertTrue($container->has(Geolocator::class), 'Geolocator class is wired');
+        $this->assertTrue($container->has(VatNumberValidator::class), 'VatNumberValidator class is wired');
     }
 }


### PR DESCRIPTION
The problem:

[VatNumberValidator](https://github.com/ibericode/vat-bundle/blob/b1c34c9eb34d867f8ee664374029e445c31ca6c7/src/Validator/Constraints/VatNumberValidator.php#L31) uses "new" instead of autowiring, therefore I'm unable to replace service with different Vies Client (rest).

This change will make this possible.

Please review it and let me know if it needs adjustments.

I also added intl and soap extensions as after `composer install` these are actually required during development.

I tested the dev branch in my app and can confirm it works as expected.