### PR TITLE
Fix services.xml configuration for VatNumberValidator

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -19,8 +19,8 @@
         <service id="ibericode_vat.geolocator" class="Ibericode\Vat\Geolocator">
             <argument key="$service">%ibericode_vat.geolocator.service%</argument>
         </service>
-        <service id="Ibericode\Vat\Bundle\Validator\Constraints\VatNumberValidator">
-            <argument key="$validator">%ibericode_vat.validator%</argument>
+        <service id="ibericode_vat.validator.vat_number_validator" class="Ibericode\Vat\Bundle\Validator\Constraints\VatNumberValidator">
+            <argument key="$validator" type="service" id="ibericode_vat.validator"/>
         </service>
 
         <!-- autowiring class names -->
@@ -28,5 +28,6 @@
         <service id="Ibericode\Vat\Validator" alias="ibericode_vat.validator" />
         <service id="Ibericode\Vat\Rates" alias="ibericode_vat.rates" />
         <service id="Ibericode\Vat\Geolocator" alias="ibericode_vat.geolocator" />
+        <service id="Ibericode\Vat\Bundle\Validator\Constraints\VatNumberValidator" alias="ibericode_vat.validator.vat_number_validator" />
     </services>
 </container>

--- a/tests/DependencyInjection/VatExtensionTest.php
+++ b/tests/DependencyInjection/VatExtensionTest.php
@@ -10,6 +10,7 @@ use Ibericode\Vat\Validator;
 use Ibericode\Vat\Bundle\DependencyInjection\VatExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Reference;
 
 class VatExtensionTest extends TestCase
 {
@@ -27,6 +28,19 @@ class VatExtensionTest extends TestCase
         $this->assertTrue($container->has(Rates::class), 'Rates class is wired');
         $this->assertTrue($container->has(Validator::class), 'Validator class is wired');
         $this->assertTrue($container->has(Geolocator::class), 'Geolocator class is wired');
+    }
+
+    public function testVatNumberValidator()
+    {
+        $container = new ContainerBuilder();
+        $loader = new VatExtension();
+        $loader->load([[]], $container);
+
+        $this->assertTrue($container->hasDefinition('ibericode_vat.validator.vat_number_validator'));
         $this->assertTrue($container->has(VatNumberValidator::class), 'VatNumberValidator class is wired');
+
+        $validatorRef = $container->getDefinition('ibericode_vat.validator.vat_number_validator')->getArgument('$validator');
+        $this->assertInstanceOf(Reference::class, $validatorRef);
+        $this->assertSame('ibericode_vat.validator', (string) $validatorRef);
     }
 }


### PR DESCRIPTION
In previous PR (#9) I made a mistake in services.xml. Fortunately, it does not break anything thanks to the default value set in constructor.

Sorry for the fuss.

