### PR TITLE
Fix dependency injection deprecation

### DIFF
--- a/src/DependencyInjection/VatExtension.php
+++ b/src/DependencyInjection/VatExtension.php
@@ -2,10 +2,10 @@
 
 namespace Ibericode\Vat\Bundle\DependencyInjection;
 
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class VatExtension extends Extension {
 


### PR DESCRIPTION
This fixes the following deprecation: 
>  The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Ibericode\Vat\Bundle\DependencyInjection\VatExtension". 